### PR TITLE
Append "-mt" to the WEBAPP_NAME

### DIFF
--- a/instructions/0-environment-setup.md
+++ b/instructions/0-environment-setup.md
@@ -74,7 +74,7 @@ Replace the entire file with the below content, and then replace the placeholder
 
 > **HINT**: You can discover your Subscription ID with `az account show | jq -r .id`
 
-```json
+```jsonc
 {
     "terminal.integrated.env.linux": {
         // Obtain your subscription ID with hint above
@@ -82,7 +82,7 @@ Replace the entire file with the below content, and then replace the placeholder
 
         // these must be unique to you, consider using initials of your name
         "DB_SERVER_NAME": "[Your initials]-postgres-database",
-        "WEBAPP_NAME": "[Your initials]-webapp",
+        "WEBAPP_NAME": "[Your initials]-webapp-mt",
 
         // this must be unique to you, and different from WEBAPP_NAME
         "ASE_WEBAPP_NAME": "[Your initials]-ase-webapp",

--- a/instructions/1-environment-setup.md
+++ b/instructions/1-environment-setup.md
@@ -82,7 +82,7 @@ Replace the entire file with the below content, and then replace the placeholder
 
         // these must be unique to you, consider using initials of your name
         "DB_SERVER_NAME": "[Your initials]-postgres-database",
-        "WEBAPP_NAME": "[Your initials]-webapp-mt",
+        "WEBAPP_NAME": "[Your initials]-webapp",
 
         // this must be the same name from the ARM template you deployed earlier, and different from WEBAPP_NAME
         "ASE_WEBAPP_NAME": "[Your initials]-ase-webapp",

--- a/instructions/1-environment-setup.md
+++ b/instructions/1-environment-setup.md
@@ -84,7 +84,7 @@ Replace the entire file with the below content, and then replace the placeholder
         "DB_SERVER_NAME": "[Your initials]-postgres-database",
         "WEBAPP_NAME": "[Your initials]-webapp-mt",
 
-        // this must be unique to you, and different from WEBAPP_NAME
+        // this must be the same name from the ARM template you deployed earlier, and different from WEBAPP_NAME
         "ASE_WEBAPP_NAME": "[Your initials]-ase-webapp",
 
         // these are OK to be hard-coded


### PR DESCRIPTION
This will prevent naming conflicts when/if the user tries to create the multitenant webapp with the same name as the ASE webapp