### PR TITLE
Update 2-learn-about-app-service.md

### DIFF
--- a/instructions/2-learn-about-app-service.md
+++ b/instructions/2-learn-about-app-service.md
@@ -52,13 +52,13 @@ First, we will need a new resource group to house the resources we will create i
         --is-linux
     ```
 
-2. Once the App Service Plan is created, create a JBoss EAP web app on the Plan.
+1. Once the App Service Plan is created, create a JBoss EAP web app on the Plan.
 
     ```bash
     az webapp create \
         --name $WEBAPP_NAME \
         --resource-group $RESOURCE_GROUP \
-        --runtime "JBOSSEAP|7.3-java11" \
+        --runtime "JBOSSEAP|7-java11" \
         --plan "workshop-app-service-plan"
     ```
 


### PR DESCRIPTION
Closes #96

@jamesfalkner -- FYI the reason this broke is because we made a change on the API that lists the JBoss versions to include patch versions, like we do for Tomcat and Java SE. When we did that I marked "JBOSSEAP|7.3-java11" as hidden so people would use the patch versions. The CLI doesn't honor hidden stacks. So net-net, it was a one-time schema change.