### PR TITLE
Bumps Maven version to latest patch release

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -21,7 +21,7 @@ ENV JAVA_HOME=/usr/local/jdk-11.0.12+7
 ENV PATH=$JAVA_HOME/bin:$PATH
 
 # maven
-ENV MVN_DIST=https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz
+ENV MVN_DIST=https://dlcdn.apache.org/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz
 
 RUN wget -q -O /tmp/maven.tar.gz $MVN_DIST && \
     cd /usr/local && \


### PR DESCRIPTION
Hello.
Thank you for providing the workshop.

gitpod won't run because maven is released as 3.8.7
Fixed maven path of gitpod docker file.

- gitpod launch fail
- bump maven version 3.8.6 -> 3.8.7 (not available 3.8.6)